### PR TITLE
Fixed reference to account

### DIFF
--- a/includes/modules/payment/bitpay.php
+++ b/includes/modules/payment/bitpay.php
@@ -106,7 +106,7 @@
         'buyerName' => $order->customer['firstname'].' '.$order->customer['lastname'],
         'fullNotifications' => 'true',
         'notificationURL' => tep_href_link('bitpay_callback.php', '', 'SSL', true, true),
-        'redirectURL' => tep_href_link('account'),
+        'redirectURL' => tep_href_link(FILENAME_ACCOUNT),
         'transactionSpeed' => $lut[MODULE_PAYMENT_BITPAY_TRANSACTION_SPEED],
         'apiKey' => MODULE_PAYMENT_BITPAY_APIKEY,
       );


### PR DESCRIPTION
Changed line 109 reference to 'account' (which is incorrect) to the globally defined FILENAME_ACCOUNT.
