### PR TITLE
fixed error with includes, added different email footers

### DIFF
--- a/bitpay/remove_order.php
+++ b/bitpay/remove_order.php
@@ -1,0 +1,19 @@
+<?php 
+
+function tep_remove_order($order_id, $restock = false) {
+  if ($restock == 'on') {
+    $order_query = tep_db_query("select products_id, products_quantity from " . TABLE_ORDERS_PRODUCTS . " where orders_id = '" . (int)$order_id . "'");
+
+    while ($order = tep_db_fetch_array($order_query))
+      tep_db_query("update " . TABLE_PRODUCTS . " set products_quantity = products_quantity + " . $order['products_quantity'] . ", products_ordered = products_ordered - " . $order['products_quantity'] . " where products_id = '" . (int)$order['products_id'] . "'");
+
+  }
+
+  tep_db_query("delete from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
+  tep_db_query("delete from " . TABLE_ORDERS_PRODUCTS . " where orders_id = '" . (int)$order_id . "'");
+  tep_db_query("delete from " . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . " where orders_id = '" . (int)$order_id . "'");
+  tep_db_query("delete from " . TABLE_ORDERS_STATUS_HISTORY . " where orders_id = '" . (int)$order_id . "'");
+  tep_db_query("delete from " . TABLE_ORDERS_TOTAL . " where orders_id = '" . (int)$order_id . "'");
+}
+
+?>

--- a/bitpay_callback.php
+++ b/bitpay_callback.php
@@ -20,6 +20,8 @@
  */
 
 require 'bitpay/bp_lib.php';
+require 'includes/application_top.php';
+require 'bitpay/remove_order.php';
 
 $response = bpVerifyNotification(MODULE_PAYMENT_BITPAY_APIKEY);
 
@@ -31,9 +33,6 @@ if (is_string($response)) {
     case 'paid':
     case 'confirmed':
     case 'complete':
-      //require needed for tep_db_query
-      require 'includes/application_top.php';
-
       if(function_exists('tep_db_query'))
           tep_db_query("update " . TABLE_ORDERS . " set orders_status = " . MODULE_PAYMENT_BITPAY_PAID_STATUS_ID . " where orders_id = " . intval($order_id));
       else
@@ -41,13 +40,6 @@ if (is_string($response)) {
       break;
     case 'invalid':
     case 'expired':
-      //requires needed for tep_remove_order
-      require 'admin/includes/configure.php';
-      require 'admin/includes/database_tables.php';
-      require 'admin/includes/functions/database.php';
-      tep_db_connect() or die('Unable to connect to database server!');
-      require 'admin/includes/functions/general.php';
-
       if(function_exists('tep_remove_order'))
           tep_remove_order($order_id, $restock = true);
       else

--- a/includes/languages/english/modules/payment/bitpay.php
+++ b/includes/languages/english/modules/payment/bitpay.php
@@ -22,7 +22,7 @@
   // Text Messages
   define('MODULE_PAYMENT_BITPAY_TEXT_TITLE', 'Bitcoin via BitPay');
   define('MODULE_PAYMENT_BITPAY_TEXT_DESCRIPTION', 'Use bitpay.com\'s invoice processing server to automatically accept bitcoins.');
-  define('MODULE_PAYMENT_BITPAY_TEXT_EMAIL_FOOTER', 'You just paid with bitcoins via bitpay.com -- Thanks!');
+  define('MODULE_PAYMENT_BITPAY_TEXT_EMAIL_FOOTER', 'You will receive further emails from bitpay.com when the status of your order is updated.');
 
   // Error Messages
   define('MODULE_PAYMENT_BITPAY_BAD_CURRENCY', 'Currency not supported by bitpay.com.  Please choose another currency.');


### PR DESCRIPTION
Originally, I included includes/application_top.php in bitpay_callback.php only when the order was paid/confirmed/complete, and I included the other files needed to remove the order when the order was invalid or expired...but it needs application_top included at the top (go figure) in order to use the API key. I ended up just creating a file with the tep_remove_order function and included it in bitpay.php and and bitpay_callback.php. It'd be great to figure out how to include the function provided in admin/includes/function/general.php, but this works for now. 

An email is sent out by osCommerce upon clicking the Confirm Order button, but our email footer was saying that the customer had paid at this point, so I changed the base footer to better reflect what was actually going on. To change the footer during processing, it needs to be done in before_process since the email is sent before the after_process, so I put the creation of the invoice in before process, and the redirects in after_process.

Let me know how it looks and if it could be better organized
